### PR TITLE
Lichess perfs is nullable

### DIFF
--- a/backend/src/main/kotlin/com/zackmurry/chessrs/model/UserPrincipalResponse.kt
+++ b/backend/src/main/kotlin/com/zackmurry/chessrs/model/UserPrincipalResponse.kt
@@ -6,14 +6,18 @@ import java.util.*
 data class LichessPerf(val games: Int, val rating: Int, val rd: Int, val prog: Int, val prov: Boolean?) {
 
     companion object {
-        fun fromMap(map: MutableMap<String, Any>): LichessPerf {
-            return LichessPerf(
-                map["games"] as Int,
-                map["rating"] as Int,
-                map["rd"] as Int,
-                map["prog"] as Int,
-                map["prov"] as Boolean?
-            )
+        fun fromMap(map: MutableMap<String, Any>?): LichessPerf? {
+            return if (map != null) {
+                LichessPerf(
+                        map["games"] as Int,
+                        map["rating"] as Int,
+                        map["rd"] as Int,
+                        map["prog"] as Int,
+                        map["prov"] as Boolean?
+                )
+            } else {
+                null
+            }
         }
     }
 
@@ -22,44 +26,54 @@ data class LichessPerf(val games: Int, val rating: Int, val rd: Int, val prog: I
 data class LichessRacer(val runs: Int, val score: Int) {
 
     companion object {
-        fun fromMap(map: MutableMap<String, Any>) = LichessRacer(map["runs"] as Int, map["score"] as Int)
+        fun fromMap(map: MutableMap<String, Any>?): LichessRacer? {
+            return if (map != null) {
+                LichessRacer(
+                        map["runs"] as Int,
+                        map["score"] as Int
+                )
+            } else {
+                null
+            }
+        }
     }
 
 }
 
 data class LichessPerfs(
-    val chess960: LichessPerf,
-    val antichess: LichessPerf,
-    val puzzle: LichessPerf,
-    val atomic: LichessPerf,
-    val blitz: LichessPerf,
-    val crazyhouse: LichessPerf,
-    val threeCheck: LichessPerf,
-    val bullet: LichessPerf,
-    val correspondence: LichessPerf,
-    val classical: LichessPerf,
-    val rapid: LichessPerf,
-    val storm: LichessRacer,
-    val racer: LichessRacer,
-    val streak: LichessRacer
+    val chess960: LichessPerf?,
+    val antichess: LichessPerf?,
+    val puzzle: LichessPerf?,
+    val atomic: LichessPerf?,
+    val blitz: LichessPerf?,
+    val crazyhouse: LichessPerf?,
+    val threeCheck: LichessPerf?,
+    val bullet: LichessPerf?,
+    val correspondence: LichessPerf?,
+    val classical: LichessPerf?,
+    val rapid: LichessPerf?,
+    val storm: LichessRacer?,
+    val racer: LichessRacer?,
+    val streak: LichessRacer?
 ) {
     companion object {
+        @Suppress("UNCHECKED_CAST")
         fun fromMap(map: MutableMap<String, Any>): LichessPerfs {
             return LichessPerfs(
-                LichessPerf.fromMap(map["chess960"] as MutableMap<String, Any>),
-                LichessPerf.fromMap(map["antichess"] as MutableMap<String, Any>),
-                LichessPerf.fromMap(map["puzzle"] as MutableMap<String, Any>),
-                LichessPerf.fromMap(map["atomic"] as MutableMap<String, Any>),
-                LichessPerf.fromMap(map["blitz"] as MutableMap<String, Any>),
-                LichessPerf.fromMap(map["crazyhouse"] as MutableMap<String, Any>),
-                LichessPerf.fromMap(map["threeCheck"] as MutableMap<String, Any>),
-                LichessPerf.fromMap(map["bullet"] as MutableMap<String, Any>),
-                LichessPerf.fromMap(map["correspondence"] as MutableMap<String, Any>),
-                LichessPerf.fromMap(map["classical"] as MutableMap<String, Any>),
-                LichessPerf.fromMap(map["rapid"] as MutableMap<String, Any>),
-                LichessRacer.fromMap(map["storm"] as MutableMap<String, Any>),
-                LichessRacer.fromMap(map["racer"] as MutableMap<String, Any>),
-                LichessRacer.fromMap(map["streak"] as MutableMap<String, Any>),
+                LichessPerf.fromMap(map["chess960"] as MutableMap<String, Any>?),
+                LichessPerf.fromMap(map["antichess"] as MutableMap<String, Any>?),
+                LichessPerf.fromMap(map["puzzle"] as MutableMap<String, Any>?),
+                LichessPerf.fromMap(map["atomic"] as MutableMap<String, Any>?),
+                LichessPerf.fromMap(map["blitz"] as MutableMap<String, Any>?),
+                LichessPerf.fromMap(map["crazyhouse"] as MutableMap<String, Any>?),
+                LichessPerf.fromMap(map["threeCheck"] as MutableMap<String, Any>?),
+                LichessPerf.fromMap(map["bullet"] as MutableMap<String, Any>?),
+                LichessPerf.fromMap(map["correspondence"] as MutableMap<String, Any>?),
+                LichessPerf.fromMap(map["classical"] as MutableMap<String, Any>?),
+                LichessPerf.fromMap(map["rapid"] as MutableMap<String, Any>?),
+                LichessRacer.fromMap(map["storm"] as MutableMap<String, Any>?),
+                LichessRacer.fromMap(map["racer"] as MutableMap<String, Any>?),
+                LichessRacer.fromMap(map["streak"] as MutableMap<String, Any>?),
             )
         }
     }
@@ -91,6 +105,7 @@ data class LichessAttributes(
 ) {
 
     companion object {
+        @Suppress("UNCHECKED_CAST")
         fun fromMap(map: MutableMap<String, Any>): LichessAttributes {
             val perfs = LichessPerfs.fromMap(map["perfs"] as MutableMap<String, Any>)
             val playTime = LichessPlayTime.fromMap(map["playTime"] as MutableMap<String, Any>)


### PR DESCRIPTION
When logging in an error was thrown: 
```
Error getting account data from server: null cannot be cast to non-null type kotlin.collections.MutableMap<kotlin.String, kotlin.Any>
```

This is due to the fact, that lichess does not always respond with statistics to all performances when f.e no chess960 game was played. This PR makes the performances optional to make sure this does not result in an error.